### PR TITLE
Deleted unloaded blocks from Krunch

### DIFF
--- a/src/main/kotlin/org/valkyrienskies/core/game/ships/ShipObjectServerWorld.kt
+++ b/src/main/kotlin/org/valkyrienskies/core/game/ships/ShipObjectServerWorld.kt
@@ -44,7 +44,7 @@ class ShipObjectServerWorld(
     private val dimensionsAddedThisTick = ArrayList<DimensionId>()
     private val dimensionsRemovedThisTick = ArrayList<DimensionId>()
 
-    private val newLoadedChunksList = ArrayList<Pair<DimensionId, List<IVoxelShapeUpdate>>>()
+    private val newAndDeletedChunkUpdates = ArrayList<Pair<DimensionId, List<IVoxelShapeUpdate>>>()
 
     // These fields are used to generate [VSGameFrame]
     private val newShipObjects: MutableList<ShipObjectServer> = ArrayList()
@@ -108,8 +108,8 @@ class ShipObjectServerWorld(
         }
     }
 
-    fun addNewLoadedChunks(dimensionId: DimensionId, newLoadedChunks: List<IVoxelShapeUpdate>) {
-        newLoadedChunksList.add(Pair(dimensionId, newLoadedChunks))
+    fun addVoxelShapeUpdates(dimensionId: DimensionId, voxelShapeUpdates: List<IVoxelShapeUpdate>) {
+        newAndDeletedChunkUpdates.add(Pair(dimensionId, voxelShapeUpdates))
     }
 
     fun tickShips() {
@@ -141,7 +141,7 @@ class ShipObjectServerWorld(
         }
 
         // region Add voxel shape updates for chunks that loaded this tick
-        for (newLoadedChunkAndDimension in newLoadedChunksList) {
+        for (newLoadedChunkAndDimension in newAndDeletedChunkUpdates) {
             val dimensionId = newLoadedChunkAndDimension.first
             for (newLoadedChunk in newLoadedChunkAndDimension.second) {
                 val chunkPos: Vector3ic =
@@ -277,7 +277,7 @@ class ShipObjectServerWorld(
         updatedShipObjects.clear()
         deletedShipObjects.clear()
         shipToVoxelUpdates.clear()
-        newLoadedChunksList.clear()
+        newAndDeletedChunkUpdates.clear()
         dimensionsAddedThisTick.clear()
         dimensionsRemovedThisTick.forEach { dimensionRemovedThisTick: DimensionId ->
             val removedSuccessfully = dimensionToGroundBodyId.remove(dimensionRemovedThisTick) != null


### PR DESCRIPTION
Working on this issue https://github.com/ValkyrienSkies/Valkyrien-Skies-2/issues/32
Currently there is a bug which causes Krunch to switch from 1 sphere to 8 spheres per block when a certain number of blocks is loaded. This fix makes this bug more apparent as the switch is now constantly occurring as chunks are loaded/unloaded.

This switch causes ships to bounce up and down, which is very silly.

TODO: Currently this only unloads terrain from the ground body; need to make it unload chunks from ships that are deleted/unloaded as well.